### PR TITLE
Fix date timezone issues

### DIFF
--- a/src/domain/expenses-actions/services/expenses-actions.service.ts
+++ b/src/domain/expenses-actions/services/expenses-actions.service.ts
@@ -157,6 +157,7 @@ export class ExpensesActionsService {
     const amountFormatted = formatNumberToCurrency(amount);
     const newData = {
       ...data,
+      date: dateWithTimezone,
       fullDate,
       formattedTime,
       category: categoryId,

--- a/src/domain/expenses-actions/services/expenses-actions.service.ts
+++ b/src/domain/expenses-actions/services/expenses-actions.service.ts
@@ -176,9 +176,9 @@ export class ExpensesActionsService {
     changes: UpdateExpenseDto;
     categoryId: string;
   }) {
+    // Do not format date because it's already formatted when it was created
     const { date, amount } = changes;
-    const dateWithTimezone = changeTimezone(date, 'America/Mexico_City');
-    const { fullDate, formattedTime } = formatDateToString(dateWithTimezone);
+    const { fullDate, formattedTime } = formatDateToString(date);
     const amountFormatted = formatNumberToCurrency(amount);
     const newChanges = {
       ...changes,

--- a/src/domain/incomes-actions/services/incomes-actions.service.ts
+++ b/src/domain/incomes-actions/services/incomes-actions.service.ts
@@ -63,6 +63,7 @@ export class IncomesActionsService {
     const amountFormatted = formatNumberToCurrency(amount);
     const newData = {
       ...data,
+      date: dateWithTimezone,
       fullDate,
       formattedTime,
       amountFormatted,

--- a/src/domain/incomes-actions/services/incomes-actions.service.ts
+++ b/src/domain/incomes-actions/services/incomes-actions.service.ts
@@ -75,8 +75,8 @@ export class IncomesActionsService {
 
   formatEditIncome({ changes }: { changes: UpdateIncomeDto }) {
     const { date, amount } = changes;
-    const dateWithTimezone = changeTimezone(date, 'America/Mexico_City');
-    const { fullDate, formattedTime } = formatDateToString(dateWithTimezone);
+    // Do not format date because it's already formatted when it was created
+    const { fullDate, formattedTime } = formatDateToString(date);
     const amountFormatted = formatNumberToCurrency(amount);
     const newChanges = {
       ...changes,

--- a/src/domain/records/services/records.service.ts
+++ b/src/domain/records/services/records.service.ts
@@ -252,6 +252,7 @@ export class RecordsService {
 
     const newDataExpense = {
       ...expense,
+      date: dateWithTimezone,
       fullDate,
       formattedTime,
       amountFormatted,
@@ -259,6 +260,7 @@ export class RecordsService {
     };
     const newDataIncome = {
       ...income,
+      date: dateWithTimezone,
       fullDate,
       formattedTime,
       amountFormatted,


### PR DESCRIPTION
# PR Description
- Assign date formatted with timezone to the values when formatted income, expense, transfer
- Do not format with timezone again the date when edit income or expense